### PR TITLE
Update macOS version in`Available platforms` section at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can visit [our download page](https://mullvad.net/download/browser) to get t
 
 - Linux **\*** (64 bit only)
 - Windows 10 or later (64 bit only)
-- macOS 11 or later
+- macOS Sonoma (14) or later
 
 **\*** `.deb` and `.rpm` packages are available for Linux through [our repositories](https://mullvad.net/en/download/browser/linux).
 


### PR DESCRIPTION
## Description:
Currently, it is not consistent for `macOS version` in`Available platforms` section at README.md and [Mullvad website](https://mullvad.net/en/download/browser/macos) . It seems the README.md is outdated.

### github.com:
<img width="640" height="197" alt="github" src="https://github.com/user-attachments/assets/5cf10e2d-eca3-4acb-b86b-31c11506a0dc" />

### mullvad.net:
<img width="849" height="578" alt="mullvadWebsite" src="https://github.com/user-attachments/assets/1412d85c-a3cc-4ea8-97a7-1cc3c9135a12" />

## File change:
+ README.md